### PR TITLE
Make repo clean on update optional

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.coverage
 .pytest_cache
 .tox
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Settings can be configured via environmental variables.
 REPO_AGENT_BASE_DIR: /app/repositories  # Directory to clone repos to
 
 # If using the celery scheduler
+REPO_AGENT_CLEAN_ON_UPDATE: False  # Clean local repos during update (removes local untracked files)
 REPO_AGENT_UPDATE_FREQUENCY: 300  # Frequency, in seconds, for updating the registry.
 REPO_AGENT_BROKER: redis://redis:6379/10  # URL for the redis task broker
 REPO_AGENT_REPOS: https://github.com/example1/example-repo, https://github.com/example2/example-repo  # List of repositories separated by commas

--- a/repository_agent/app.py
+++ b/repository_agent/app.py
@@ -20,9 +20,12 @@ def _get_repo_dir_path(url):
     return os.path.join(BASE_DIR, repo_dir)
 
 
-def update_repo(repo_url):
+def update_repo(repo_url, clean=False):
     '''
     Update an individual repo.
+
+    `clean` determines whether the repo directory should be forcibly cleaned
+    before updating.
     '''
     repo_path = _get_repo_dir_path(repo_url)
     # If repo_path doesn't exist, create it.
@@ -39,6 +42,7 @@ def update_repo(repo_url):
         # This repo's remote corresponds with repo_url, force pull it.
         if repo_url == repo.remotes.origin.url:
             log.info('Updating "{}" from {}'.format(repo_path, repo_url))
-            repo.git.clean('-d', '-f')
+            if clean:
+                repo.git.clean('-d', '-f')
             repo.head.reset(index=True, working_tree=True)
             repo.remotes.origin.pull()

--- a/repository_agent/scheduler.py
+++ b/repository_agent/scheduler.py
@@ -12,6 +12,7 @@ log = logging.getLogger(__name__)
 REPOS = env('REPO_AGENT_REPOS', cast=list, subcast=str)
 UPDATE_FREQUENCY = env.int('REPO_AGENT_UPDATE_FREQUENCY', default=30)
 BROKER = env('REPO_AGENT_BROKER')
+CLEAN_ON_UPDATE = env('REPO_AGENT_CLEAN_ON_UPDATE', cast=bool, default=False)
 
 celeryapp = Celery(broker=BROKER)
 
@@ -30,7 +31,7 @@ def update_all_repos(repos):
 @celeryapp.task
 def update_repo_task(repo_url):
     try:
-        update_repo(repo_url)
+        update_repo(repo_url, clean=CLEAN_ON_UPDATE)
     except (GitCommandError, InvalidGitRepositoryError) as e:
         log.error('Repo update failed. Logging and moving on...')
         log.error(e)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,8 +6,7 @@ from test.support import EnvironmentVarGuard
 
 from git.exc import GitCommandError
 
-from repository_agent.app import \
-    _get_repo_dir_path, update_repo
+from repository_agent.app import _get_repo_dir_path, update_repo
 
 
 class TestGetRepoPath(unittest.TestCase):
@@ -110,3 +109,27 @@ class TestPullRepos(unittest.TestCase):
         '''
         with self.env, self.assertRaises(GitCommandError):
             update_repo('/my/local/path/to/nonexistent-repo')
+
+    def test_pull_clean_on_update(self):
+        '''
+        If clean=True, remove untracked files during update.
+        '''
+        with self.env:
+            # pull local repo to tmp directory location
+            update_repo(self.local_repo)
+
+            untracked_file = \
+                os.path.join(self.tmp_dir, 'local-example/untracked.txt')
+
+            # put an untracked file in there...
+            with open(untracked_file, "w") as f:
+                f.write("Untracked file!")
+            assert os.path.exists(untracked_file)
+
+            # pull again (without cleaning)
+            update_repo(self.local_repo, clean=False)
+            assert os.path.exists(untracked_file)
+
+            # pull again (with clean)
+            update_repo(self.local_repo, clean=True)
+            assert not os.path.exists(untracked_file)


### PR DESCRIPTION
Adds an env var option for the scheduler: `REPO_AGENT_CLEAN_ON_UPDATE: True`. If `True`, local repositories will be cleaned (untracked files removed) during update).

Fixes #1.